### PR TITLE
feat: implement multi-provider support for LLM configuration and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ git clone git@github.com:zhongyu09/openchatbi
 uv sync --group dev
 ```
 
-4. If you have issues when installing pysqlite3, try to install sqlite first:
+Optional: If you want to use `pysqlite3` (newer SQLite builds), you can install it manually. If build fails, install SQLite first:
 
 On macOS, try to install sqlite using Homebrew:
 ```bash
@@ -112,23 +112,28 @@ Or create an empty YAML file.
 2. **Configure your LLMs:**
 
 ```yaml
-# Required: Primary LLM for general tasks
-default_llm:
-  class: langchain_openai.ChatOpenAI
-  params:
-    api_key: YOUR_API_KEY_HERE
-    model: gpt-4.1
-    temperature: 0.02
-    max_tokens: 8192
+# Select which provider to use
+default_llm: openai
 
-# Optional: Embedding model for vector-based retrieval and memory tools
-# If not configured, BM25-based retrieval will be used, and the memory tools will not work
-embedding_model:
-  class: langchain_openai.OpenAIEmbeddings
-  params:
-    api_key: YOUR_API_KEY_HERE
-    model: text-embedding-3-large
-    chunk_size: 1024
+# Define one or more providers
+llm_providers:
+  openai:
+    default_llm:
+      class: langchain_openai.ChatOpenAI
+      params:
+        api_key: YOUR_API_KEY_HERE
+        model: gpt-4.1
+        temperature: 0.02
+        max_tokens: 8192
+
+    # Optional: Embedding model for vector-based retrieval and memory tools
+    # If not configured, BM25-based retrieval will be used, and the memory tools will not work
+    embedding_model:
+      class: langchain_openai.OpenAIEmbeddings
+      params:
+        api_key: YOUR_API_KEY_HERE
+        model: text-embedding-3-large
+        chunk_size: 1024
 ```
 
 3. **Configure your data warehouse:**
@@ -214,6 +219,12 @@ Document(https://python.langchain.com/api_reference/reference.html#integrations)
 - `default_llm`: Primary language model for general tasks
 - `embedding_model`: (Optional) Model for embedding generation. If not configured, BM25-based text retrieval will be used as fallback, and the memory tools will not work
 - `text2sql_llm`: (Optional) Specialized model for SQL generation. If not configured, uses `default_llm`
+
+Multiple providers (optional):
+
+- Configure multiple providers under `llm_providers` and select with `default_llm: <provider_name>`.
+- In `sample_ui/streamlit_ui.py`, a provider dropdown appears when `llm_providers` is configured.
+- In `sample_api/async_api.py`, pass `provider` in the `/chat/stream` request body.
 
 Commonly used LLM providers and their corresponding classes and installation commands:
 

--- a/openchatbi/config.yaml.template
+++ b/openchatbi/config.yaml.template
@@ -60,30 +60,40 @@ data_warehouse_config:
   user_name: TOKEN_SERVICE_USER_NAME
   password: TOKEN_SERVICE_PASSWORD
 
-# LLM configurations
-default_llm:
-  class: langchain_openai.ChatOpenAI
-  params:
-    api_key: YOUR_API_KEY_HERE
-    model: gpt-4.1
-    temperature: 0.01
-    max_tokens: 8192
-
-embedding_model:
-  class: langchain_openai.OpenAIEmbeddings
-  params:
-    api_key: YOUR_API_KEY_HERE
-    model: text-embedding-3-large
-    chunk_size: 1024
-
-# Optional
-text2sql_llm:
-  class: langchain_openai.ChatOpenAI
-  params:
-    api_key: YOUR_API_KEY_HERE
-    model: gpt-4.1
-    temperature: 0.0
-    max_tokens: 8192
+# LLM configurations (multiple providers)
+#
+# 1) Define providers under `llm_providers`
+# 2) Select which one to use by setting `default_llm: <provider_name>`
+default_llm: openai
+llm_providers:
+  openai:
+    default_llm:
+      class: langchain_openai.ChatOpenAI
+      params:
+        api_key: YOUR_API_KEY_HERE
+        model: gpt-4.1
+        temperature: 0.01
+        max_tokens: 8192
+    embedding_model:
+      class: langchain_openai.OpenAIEmbeddings
+      params:
+        api_key: YOUR_API_KEY_HERE
+        model: text-embedding-3-large
+        chunk_size: 1024
+    # Optional
+    text2sql_llm:
+      class: langchain_openai.ChatOpenAI
+      params:
+        api_key: YOUR_API_KEY_HERE
+        model: gpt-4.1
+        temperature: 0.0
+        max_tokens: 8192
+  # anthropic:
+  #   default_llm:
+  #     class: langchain_anthropic.ChatAnthropic
+  #     params:
+  #       api_key: YOUR_API_KEY_HERE
+  #       model: claude-3-5-sonnet-latest
 
 # MCP (Model Context Protocol) server configurations
 mcp_servers:

--- a/openchatbi/tool/memory.py
+++ b/openchatbi/tool/memory.py
@@ -2,9 +2,12 @@ import functools
 import sys
 from typing import Any
 
-import pysqlite3 as sqlite3
+try:
+    import pysqlite3 as sqlite3
+except ImportError:  # pragma: no cover
+    import sqlite3
 
-# make sure langgraph sqlite connector uses pysqlite3
+# Make sure langgraph sqlite connector uses the same sqlite module.
 sys.modules["sqlite3"] = sqlite3
 
 from langchain.tools import StructuredTool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ dependencies = [
     "langmem>=0.0.29",
     "sqlalchemy>=2.0.41,<3.0.0",
     "sqlalchemy-trino>=0.5.0",
-    "pysqlite3>=0.5.4",
     "aiosqlite>=0.21.0",
     "pyhive[presto]>=0.7.0",
     "rank-bm25>=0.2.2,<1.0.0",
@@ -257,4 +256,3 @@ exclude_lines = [
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
 ]
-

--- a/sample_ui/async_graph_manager.py
+++ b/sample_ui/async_graph_manager.py
@@ -1,11 +1,12 @@
 """Common AsyncGraphManager for UIs."""
 
+from typing import Any
+
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 from openchatbi import config
 from openchatbi.agent_graph import build_agent_graph_async
-from openchatbi.llm.llm import get_default_llm
-from openchatbi.tool.memory import cleanup_async_memory_store, get_async_memory_tools, setup_async_memory_store
+from openchatbi.tool.memory import cleanup_async_memory_store, get_async_memory_store, setup_async_memory_store
 from openchatbi.utils import log
 
 
@@ -14,8 +15,10 @@ class AsyncGraphManager:
 
     def __init__(self):
         self.checkpointer = None
-        self.graph = None
+        self.graph = None  # Default graph (backwards compatible)
+        self.graphs: dict[str, Any] = {}
         self._context_manager = None
+        self._memory_store = None
         self._initialized = False
 
     async def initialize(self):
@@ -31,26 +34,39 @@ class AsyncGraphManager:
             self._context_manager = AsyncSqliteSaver.from_conn_string("checkpoints.db")
             self.checkpointer = await self._context_manager.__aenter__()
 
-            # Get async memory tools
-            from openchatbi.tool.memory import get_async_memory_store
-
-            async_store = await get_async_memory_store()
-            async_memory_tools = await get_async_memory_tools(get_default_llm())
-
-            # Build the graph
-            self.graph = await build_agent_graph_async(
-                config.get().catalog_store,
-                checkpointer=self.checkpointer,
-                memory_store=async_store,
-                memory_tools=async_memory_tools,
-            )
+            # Cache store for graph builds
+            self._memory_store = await get_async_memory_store()
 
             self._initialized = True
+
+            # Build default graph for backwards compatibility
+            self.graph = await self.get_graph()
+
             log("Graph initialized successfully")
 
         except Exception as e:
+            self._initialized = False
             log(f"Failed to initialize graph: {e}")
             raise
+
+    async def get_graph(self, llm_provider: str | None = None):
+        """Get or build a graph for the requested LLM provider."""
+        if not self._initialized:
+            await self.initialize()
+
+        key = llm_provider or "__default__"
+        if key in self.graphs:
+            return self.graphs[key]
+
+        graph = await build_agent_graph_async(
+            config.get().catalog_store,
+            checkpointer=self.checkpointer,
+            memory_store=self._memory_store,
+            memory_tools=None,  # Let graph builder create provider-appropriate tools
+            llm_provider=llm_provider,
+        )
+        self.graphs[key] = graph
+        return graph
 
     async def cleanup(self):
         """Cleanup resources"""
@@ -64,5 +80,7 @@ class AsyncGraphManager:
             finally:
                 self.checkpointer = None
                 self.graph = None
+                self.graphs = {}
                 self._context_manager = None
+                self._memory_store = None
                 self._initialized = False

--- a/sample_ui/streaming_ui.py
+++ b/sample_ui/streaming_ui.py
@@ -6,7 +6,10 @@ from collections import defaultdict
 from contextlib import asynccontextmanager
 
 import gradio as gr
-import pysqlite3 as sqlite3
+try:
+    import pysqlite3 as sqlite3
+except ImportError:  # pragma: no cover
+    import sqlite3
 from fastapi import FastAPI
 from langchain_core.messages import AIMessage
 

--- a/tests/context_management/test_agent_graph_integration.py
+++ b/tests/context_management/test_agent_graph_integration.py
@@ -105,7 +105,7 @@ class TestAgentGraphIntegration:
             patch("openchatbi.agent_graph.build_sql_graph") as mock_sql_graph,
             patch("openchatbi.agent_graph.get_memory_tools") as mock_memory_tools,
             patch("openchatbi.agent_graph.create_mcp_tools_sync") as mock_mcp_tools,
-            patch("openchatbi.agent_graph.get_default_llm", return_value=mock_llm),
+            patch("openchatbi.agent_graph.get_llm", return_value=mock_llm),
         ):
 
             # Setup function-based mocks
@@ -152,7 +152,7 @@ class TestAgentGraphIntegration:
             patch("openchatbi.agent_graph.build_sql_graph") as mock_sql_graph,
             patch("openchatbi.agent_graph.get_memory_tools") as mock_memory_tools,
             patch("openchatbi.agent_graph.create_mcp_tools_sync") as mock_mcp_tools,
-            patch("openchatbi.agent_graph.get_default_llm", return_value=mock_llm),
+            patch("openchatbi.agent_graph.get_llm", return_value=mock_llm),
         ):
 
             # Setup function-based mocks

--- a/uv.lock
+++ b/uv.lock
@@ -2912,7 +2912,6 @@ dependencies = [
     { name = "pandas" },
     { name = "plotly" },
     { name = "pyhive", extra = ["presto"] },
-    { name = "pysqlite3" },
     { name = "python-levenshtein" },
     { name = "rank-bm25" },
     { name = "requests" },
@@ -3003,7 +3002,6 @@ requires-dist = [
     { name = "plotly", specifier = ">=5.17.0,<6.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.1,<5.0.0" },
     { name = "pyhive", extras = ["presto"], specifier = ">=0.7.0" },
-    { name = "pysqlite3", specifier = ">=0.5.4" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.4.0,<9.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.8,<1.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0,<7.0.0" },
@@ -3906,12 +3904,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817a
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
 ]
-
-[[package]]
-name = "pysqlite3"
-version = "0.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/cb/ef7d041dbecfbf47f9241d7cb6328311fd80fe15bd61a6253d9ab36e9d6d/pysqlite3-0.5.4.tar.gz", hash = "sha256:fbc69bfdc0cb43a5badd5403b126d5151371b5037e0397ba9802bb440c5b0021", size = 40743, upload-time = "2024-10-12T12:11:55.537Z" }
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
This pull request introduces support for configuring multiple LLM (Large Language Model) providers, allowing users to select which provider to use for chat, embedding, and SQL generation tasks. The changes span documentation, configuration files, and core logic, making the system more flexible and extensible for various LLM backends.

**Multi-provider LLM configuration and selection:**

* Added support for multiple LLM providers in configuration via the new `llm_providers` section and `default_llm` selector in both `config.yaml.template` and `README.md`. This enables users to define several providers and choose one as the default, with examples for OpenAI and Anthropic. [[1]](diffhunk://#diff-31585b374256ecb27e38e49a4ac38d46854da24ecea49afa5f6296f5d5d61952L63-L78) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R120) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R223-R228) [[4]](diffhunk://#diff-31585b374256ecb27e38e49a4ac38d46854da24ecea49afa5f6296f5d5d61952R91-R96)
* Refactored `openchatbi/config_loader.py` to process and instantiate multiple LLM providers, resolve the selected provider, and expose provider-specific models for chat, embedding, and SQL generation. [[1]](diffhunk://#diff-03b08b0ce4a49b47bf461e9a1f177489cce24880a90ede19d25c310e50a75478R14-R23) [[2]](diffhunk://#diff-03b08b0ce4a49b47bf461e9a1f177489cce24880a90ede19d25c310e50a75478R47-R49) [[3]](diffhunk://#diff-03b08b0ce4a49b47bf461e9a1f177489cce24880a90ede19d25c310e50a75478L143-R199) [[4]](diffhunk://#diff-03b08b0ce4a49b47bf461e9a1f177489cce24880a90ede19d25c310e50a75478L178-R276)

**Core logic updates for provider selection:**

* Updated `openchatbi/llm/llm.py` to support provider-aware model retrieval functions (`get_llm`, `get_embedding_model`, `get_text2sql_llm`, etc.), allowing runtime selection of LLM provider. Also added a utility to list available providers.
* Modified agent graph and SQL graph construction in `openchatbi/agent_graph.py` and `openchatbi/text2sql/sql_graph.py` to accept and pass the `llm_provider` parameter, ensuring correct model selection throughout the pipeline. [[1]](diffhunk://#diff-1b3ea77f8dc7d3ca197cd7545787b1b4878484c97905545eed2ed4e3f7dc3cabL28-R28) [[2]](diffhunk://#diff-1b3ea77f8dc7d3ca197cd7545787b1b4878484c97905545eed2ed4e3f7dc3cabR281) [[3]](diffhunk://#diff-1b3ea77f8dc7d3ca197cd7545787b1b4878484c97905545eed2ed4e3f7dc3cabL296-R302) [[4]](diffhunk://#diff-1b3ea77f8dc7d3ca197cd7545787b1b4878484c97905545eed2ed4e3f7dc3cabL322-R333) [[5]](diffhunk://#diff-1b3ea77f8dc7d3ca197cd7545787b1b4878484c97905545eed2ed4e3f7dc3cabR380) [[6]](diffhunk://#diff-1b3ea77f8dc7d3ca197cd7545787b1b4878484c97905545eed2ed4e3f7dc3cabR404) [[7]](diffhunk://#diff-1b3ea77f8dc7d3ca197cd7545787b1b4878484c97905545eed2ed4e3f7dc3cabR414) [[8]](diffhunk://#diff-1b3ea77f8dc7d3ca197cd7545787b1b4878484c97905545eed2ed4e3f7dc3cabR442) [[9]](diffhunk://#diff-e0f7e6384c21f78f53ef0609cf5587a7cdbe7d30bd679f14d1782d33bc3fb40fL15-R15) [[10]](diffhunk://#diff-e0f7e6384c21f78f53ef0609cf5587a7cdbe7d30bd679f14d1782d33bc3fb40fL61-R63) [[11]](diffhunk://#diff-e0f7e6384c21f78f53ef0609cf5587a7cdbe7d30bd679f14d1782d33bc3fb40fL74-R86)

**Documentation and configuration improvements:**

* Enhanced documentation in `README.md` to explain multi-provider setup and usage, including UI/API integration details and troubleshooting for `pysqlite3`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R71) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R120) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R223-R228)
* Updated `config.yaml.template` with clear examples and comments for multi-provider configuration. [[1]](diffhunk://#diff-31585b374256ecb27e38e49a4ac38d46854da24ecea49afa5f6296f5d5d61952L63-L78) [[2]](diffhunk://#diff-31585b374256ecb27e38e49a4ac38d46854da24ecea49afa5f6296f5d5d61952R91-R96)

**Dependency and SQLite compatibility:**

* Improved SQLite compatibility by conditionally importing `pysqlite3` and falling back to `sqlite3` if unavailable, ensuring consistent behavior for memory tools. Also removed `pysqlite3` from the default dependencies in `pyproject.toml`. [[1]](diffhunk://#diff-8363d01c9f7a73680ec8ba1476ab817162dacf7010b7355a7ddfb18d3d5bbfe1R5-R10) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L63)

These changes collectively make the system more robust, configurable, and ready for integration with various LLM providers.

> ran uv run pytest -q --> all tests pass