### PR TITLE
fix: text2sql confidence evaluator failure handling

### DIFF
--- a/openchatbi/graph_state.py
+++ b/openchatbi/graph_state.py
@@ -46,7 +46,9 @@ class SQLGraphState(MessagesState):
     previous_sql_errors: list[dict[str, Any]]
     visualization_dsl: dict[str, Any]
     sql_confidence: float
+    confidence_status: str
     confidence_reasons: list[str]
+    confidence_diagnostics: list[str]
     human_sql_decision: str
     recovery_strategy: str  # Last error's recovery strategy (empty if none); see RecoveryStrategy
 
@@ -79,6 +81,8 @@ class SQLOutputState(MessagesState):
     data: str  # CSV data for display
     visualization_dsl: dict[str, Any]
     sql_confidence: float
+    confidence_status: str
     confidence_reasons: list[str]
+    confidence_diagnostics: list[str]
     human_sql_decision: str
     recovery_strategy: str  # Last error's recovery strategy (empty if none); see RecoveryStrategy

--- a/openchatbi/streaming.py
+++ b/openchatbi/streaming.py
@@ -345,12 +345,28 @@ class AgentStreamProcessor:
 
             elif node_name == "score_sql":
                 score = node_output.get("sql_confidence")
+                status = node_output.get("confidence_status")
                 if score is not None:
                     reasons = node_output.get("confidence_reasons", [])
                     reason_txt = f" — {'; '.join(reasons)}" if reasons else ""
                     desc = f"🎯 SQL confidence: {score:.2f}{reason_txt}"
                     kind = "confidence"
-                    data = {"sql_confidence": score, "confidence_reasons": reasons}
+                    data = {
+                        "sql_confidence": score,
+                        "confidence_status": status or "ok",
+                        "confidence_reasons": reasons,
+                        "confidence_diagnostics": node_output.get("confidence_diagnostics", []),
+                    }
+                elif status:
+                    diagnostics = node_output.get("confidence_diagnostics") or node_output.get("confidence_reasons", [])
+                    detail_txt = f" — {'; '.join(diagnostics)}" if diagnostics else ""
+                    desc = f"🎯 SQL confidence unavailable ({status}){detail_txt}"
+                    kind = "confidence"
+                    data = {
+                        "confidence_status": status,
+                        "confidence_reasons": node_output.get("confidence_reasons", []),
+                        "confidence_diagnostics": diagnostics,
+                    }
             elif node_name == "use_tool":
                 for message in _message_list(node_output.get("messages")):
                     if not isinstance(message, ToolMessage):

--- a/openchatbi/text2sql/confidence.py
+++ b/openchatbi/text2sql/confidence.py
@@ -19,6 +19,10 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from openchatbi.llm.llm import get_default_llm
 from openchatbi.utils import extract_json_from_answer, log
 
+CONFIDENCE_STATUS_OK = "ok"
+CONFIDENCE_STATUS_PARSE_ERROR = "parse_error"
+CONFIDENCE_STATUS_EVALUATOR_ERROR = "evaluator_error"
+
 # Ordered rubric check keys (Dataherald 6-step rubric).
 RUBRIC_CHECKS: tuple[str, ...] = (
     "select_columns",  # SELECT columns map to the question's requested fields
@@ -43,9 +47,10 @@ def _get_rubric_prompt_template() -> str:
 
 @dataclass
 class ConfidenceResult:
-    score: float
+    score: float | None
     reasons: list[str] = field(default_factory=list)
     checks: dict[str, bool] = field(default_factory=dict)
+    status: str = CONFIDENCE_STATUS_OK
 
 
 class SimpleSQLEvaluator:
@@ -103,7 +108,12 @@ class SimpleSQLEvaluator:
             return self._parse(getattr(response, "content", str(response)))
         except Exception as exc:  # never raise into the calling graph
             log(f"SimpleSQLEvaluator.evaluate failed: {exc}")
-            return ConfidenceResult(score=0.0, reasons=[f"evaluator error: {exc}"], checks={})
+            return ConfidenceResult(
+                score=None,
+                reasons=[f"evaluator error: {exc}"],
+                checks={},
+                status=CONFIDENCE_STATUS_EVALUATOR_ERROR,
+            )
 
     @staticmethod
     def _parse(content: str) -> ConfidenceResult:
@@ -111,7 +121,12 @@ class SimpleSQLEvaluator:
         # objects; it returns {} on any parse failure.
         data = extract_json_from_answer(content)
         if not data:
-            return ConfidenceResult(score=0.0, reasons=["unparseable evaluator output"], checks={})
+            return ConfidenceResult(
+                score=None,
+                reasons=["unparseable evaluator output"],
+                checks={},
+                status=CONFIDENCE_STATUS_PARSE_ERROR,
+            )
 
         checks = {}
         for k in RUBRIC_CHECKS:
@@ -138,4 +153,4 @@ class SimpleSQLEvaluator:
         else:
             reasons = []
 
-        return ConfidenceResult(score=score, reasons=reasons, checks=checks)
+        return ConfidenceResult(score=score, reasons=reasons, checks=checks, status=CONFIDENCE_STATUS_OK)

--- a/openchatbi/text2sql/generate_sql.py
+++ b/openchatbi/text2sql/generate_sql.py
@@ -27,7 +27,7 @@ from openchatbi.memory_scoring import composite_score
 from openchatbi.observability.audit import AuditLogger
 from openchatbi.observability.context import get_run_context
 from openchatbi.prompts.system_prompt import get_text2sql_dialect_prompt_template
-from openchatbi.text2sql.confidence import SimpleSQLEvaluator
+from openchatbi.text2sql.confidence import CONFIDENCE_STATUS_EVALUATOR_ERROR, CONFIDENCE_STATUS_OK, SimpleSQLEvaluator
 from openchatbi.text2sql.data import get_learned_sql_store, sql_example_dicts, sql_example_retriever
 from openchatbi.text2sql.errors import (
     EmptyResultError,
@@ -378,10 +378,10 @@ def create_sql_nodes(
             # S2 gate (success != correct): only promote SQL scored above the
             # threshold, unless a human explicitly approved it.
             if not human_approved:
-                score = state.get("sql_confidence")
-                if score is None:
-                    log("Pattern capture skipped: no confidence score available")
+                if not _has_valid_confidence_score(state):
+                    log("Pattern capture skipped: confidence status is not valid")
                     return
+                score = state.get("sql_confidence")
                 try:
                     threshold = float(getattr(config.get(), "sql_confidence_threshold", 0.7))
                 except ValueError:
@@ -401,6 +401,20 @@ def create_sql_nodes(
             )
         except Exception as e:  # never let capture break the response
             log(f"Pattern capture error (ignored): {e}")
+
+    def _has_valid_confidence_score(state: SQLGraphState) -> bool:
+        """Return True only when sql_confidence is a trusted evaluator score."""
+        if state.get("sql_confidence") is None:
+            return False
+        return state.get("confidence_status", CONFIDENCE_STATUS_OK) == CONFIDENCE_STATUS_OK
+
+    def _confidence_score_meets_threshold(state: SQLGraphState, threshold: float) -> bool:
+        if not _has_valid_confidence_score(state):
+            return False
+        try:
+            return float(state["sql_confidence"]) >= threshold
+        except (TypeError, ValueError):
+            return False
 
     def generate_sql_node(state: SQLGraphState) -> dict:
         """First node: Generates initial SQL query based on the state.
@@ -704,11 +718,24 @@ def create_sql_nodes(
             result = evaluator.evaluate(question, sql_query, schema_info, data_sample, table_schema=table_schema)
         except Exception as e:  # never block the answer on evaluator failure
             log(f"Confidence evaluation failed: {str(e)}")
-            return {}
-        log(f"SQL confidence={result.score:.2f} reasons={result.reasons}")
-        return {"sql_confidence": result.score, "confidence_reasons": list(result.reasons)}
+            return {
+                "confidence_status": CONFIDENCE_STATUS_EVALUATOR_ERROR,
+                "confidence_reasons": [f"evaluator error: {e}"],
+                "confidence_diagnostics": [f"evaluator error: {e}"],
+            }
+        update = {
+            "confidence_status": result.status,
+            "confidence_reasons": list(result.reasons),
+            "confidence_diagnostics": [] if result.status == CONFIDENCE_STATUS_OK else list(result.reasons),
+        }
+        if result.status == CONFIDENCE_STATUS_OK and result.score is not None:
+            log(f"SQL confidence={result.score:.2f} reasons={result.reasons}")
+            update["sql_confidence"] = result.score
+        else:
+            log(f"SQL confidence unavailable ({result.status}): {result.reasons}")
+        return update
 
-    def _capture_golden_sql(state: SQLGraphState) -> None:
+    def _capture_golden_sql(state: SQLGraphState, human_approved: bool = False) -> None:
         """Dual-write an approved SQL: S3 vector store + durable YAML (mandatory)."""
         try:
             cfg = config.get()
@@ -721,6 +748,14 @@ def create_sql_nodes(
         tables = [d["table"] for d in state.get("tables", []) if isinstance(d, dict) and d.get("table")]
         if not question or not sql_query:
             return
+        if not human_approved:
+            try:
+                threshold = float(getattr(cfg, "sql_confidence_threshold", 0.7))
+            except (TypeError, ValueError):
+                threshold = 0.7
+            if not _confidence_score_meets_threshold(state, threshold):
+                log("Golden SQL capture skipped: confidence is unavailable or below threshold")
+                return
         # 1) runtime vector store (S3) — under the store's own lock.
         try:
             store = get_learned_sql_store()
@@ -747,9 +782,11 @@ def create_sql_nodes(
         except ValueError:
             enabled, threshold = False, 0.7
         score = state.get("sql_confidence", 1.0)
-        if not enabled or score is None or score >= threshold:
-            _capture_golden_sql(state)
-            _maybe_capture_pattern(state)
+        valid_score = _has_valid_confidence_score(state)
+        if not enabled or not valid_score or score is None or score >= threshold:
+            if _confidence_score_meets_threshold(state, threshold):
+                _capture_golden_sql(state)
+                _maybe_capture_pattern(state)
             return {"human_sql_decision": "approve"}
         reasons = state.get("confidence_reasons", [])
         feedback = interrupt(
@@ -770,7 +807,7 @@ def create_sql_nodes(
             log("Confidence gate: 'edit' without SQL payload, degrading to reject")
             decision = "reject"
         if decision == "approve":
-            _capture_golden_sql(state)
+            _capture_golden_sql(state, human_approved=True)
             # Human approval overrides the score threshold for pattern capture.
             _maybe_capture_pattern(state, human_approved=True)
         return {"human_sql_decision": decision}

--- a/openchatbi/tool/memory.py
+++ b/openchatbi/tool/memory.py
@@ -196,7 +196,7 @@ class StructuredToolWithRequired(StructuredTool):
                 if model_config:
                     model_config["json_schema_extra"] = fix_schema_for_openai
                 elif ConfigDict is not None:
-                    setattr(tcs, "model_config", ConfigDict(json_schema_extra=fix_schema_for_openai))
+                    tcs.model_config = ConfigDict(json_schema_extra=fix_schema_for_openai)
         except Exception as e:
             logger.warning("Unable to attach OpenAI schema compatibility hook: %s", e)
         return tcs

--- a/sample_ui/streamlit_ui.py
+++ b/sample_ui/streamlit_ui.py
@@ -214,7 +214,7 @@ async def process_user_message_stream(
     # Final update to response container - only show plot if available (text response is in thinking container)
     with response_container:
         if plot_figure:
-            st.plotly_chart(plot_figure, use_container_width=True, key=str(uuid.uuid4()))
+            st.plotly_chart(plot_figure, width="stretch", key=str(uuid.uuid4()))
 
     # Extract final answer for separate storage
     final_answer_text = ""
@@ -423,7 +423,7 @@ def display_message_with_thinking(
 
         # Display plot if available (outside thinking container)
         if plot_figure:
-            st.plotly_chart(plot_figure, use_container_width=True, key=str(uuid.uuid4()))
+            st.plotly_chart(plot_figure, width="stretch", key=str(uuid.uuid4()))
 
 
 # Main UI
@@ -508,7 +508,7 @@ for msg in st.session_state.messages:
 
             # Display plot if available (outside thinking container)
             if msg.get("plot_figure"):
-                st.plotly_chart(msg["plot_figure"], use_container_width=True, key=str(uuid.uuid4()))
+                st.plotly_chart(msg["plot_figure"], width="stretch", key=str(uuid.uuid4()))
 
     elif msg["type"] == "thinking_message":
         display_message_with_thinking(
@@ -519,7 +519,7 @@ for msg in st.session_state.messages:
             if msg["type"] == "text":
                 render_content_with_downloads(msg["content"])
             elif msg["type"] == "plot" and msg.get("plot_figure"):
-                st.plotly_chart(msg["plot_figure"], use_container_width=True, key=str(uuid.uuid4()))
+                st.plotly_chart(msg["plot_figure"], width="stretch", key=str(uuid.uuid4()))
 
 # Chat input
 if prompt := st.chat_input("Ask me anything about your data..."):

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -6,7 +6,13 @@ from unittest.mock import Mock
 from langchain_core.language_models import FakeListChatModel
 from langchain_core.messages import AIMessage
 
-from openchatbi.text2sql.confidence import ConfidenceResult, SimpleSQLEvaluator
+from openchatbi.text2sql.confidence import (
+    CONFIDENCE_STATUS_EVALUATOR_ERROR,
+    CONFIDENCE_STATUS_OK,
+    CONFIDENCE_STATUS_PARSE_ERROR,
+    ConfidenceResult,
+    SimpleSQLEvaluator,
+)
 
 
 def test_confidence_result_fields():
@@ -23,6 +29,7 @@ def test_confidence_result_fields():
         },
     )
     assert result.score == 0.83
+    assert result.status == CONFIDENCE_STATUS_OK
     assert result.reasons == ["WHERE clause matches the date filter"]
     assert result.checks["select_columns"] is True
     assert set(result.checks) == {
@@ -63,6 +70,7 @@ def test_evaluate_parses_structured_verdict():
     )
     assert isinstance(result, ConfidenceResult)
     assert result.score == 0.92
+    assert result.status == CONFIDENCE_STATUS_OK
     assert result.checks["joins"] is True
     assert all(result.checks[k] for k in result.checks)
     assert "columns match" in result.reasons
@@ -76,12 +84,26 @@ def test_evaluate_clamps_score_and_handles_false_checks():
     assert result.checks["where"] is False
 
 
-def test_evaluate_never_raises_on_bad_output():
+def test_evaluate_never_raises_on_bad_output_and_marks_parse_error():
     mock_llm = FakeListChatModel(responses=["not json at all"])
     evaluator = SimpleSQLEvaluator(llm=mock_llm)
     result = evaluator.evaluate("q", "SELECT 1", {}, None)
-    assert result.score == 0.0
+    assert result.score is None
+    assert result.status == CONFIDENCE_STATUS_PARSE_ERROR
+    assert result.reasons == ["unparseable evaluator output"]
     assert result.checks == {}
+
+
+def test_evaluate_never_raises_on_invocation_error_and_marks_evaluator_error():
+    mock_llm = Mock()
+    mock_llm.bind.side_effect = TypeError("no bind")
+    mock_llm.invoke.side_effect = RuntimeError("boom")
+    evaluator = SimpleSQLEvaluator(llm=mock_llm)
+    result = evaluator.evaluate("q", "SELECT 1", {}, None)
+    assert result.score is None
+    assert result.status == CONFIDENCE_STATUS_EVALUATOR_ERROR
+    assert result.checks == {}
+    assert "evaluator error: boom" in result.reasons
 
 
 def _recording_llm() -> Mock:

--- a/tests/test_golden_sql_capture.py
+++ b/tests/test_golden_sql_capture.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, Mock, patch
 
 from openchatbi.config_loader import Config
+from openchatbi.text2sql.confidence import CONFIDENCE_STATUS_PARSE_ERROR
 
 
 class TestGoldenSqlConfig:
@@ -120,6 +121,43 @@ class TestGoldenCaptureOnApprove:
         ):
             gate(state)
         learned_store.add_golden_sql.assert_not_called()
+
+    def test_confidence_unavailable_skips_golden_capture(self, mock_catalog_store):
+        from openchatbi.config_loader import Config
+        from openchatbi.constants import SQL_SUCCESS
+        from openchatbi.graph_state import SQLGraphState
+
+        cfg = Config(
+            default_llm=MagicMock(),
+            data_warehouse_config={"uri": "sqlite:///:memory:"},
+            catalog_store=mock_catalog_store,
+            enable_confidence_gate=True,
+            sql_confidence_threshold=0.7,
+            enable_golden_sql=True,
+        )
+        learned_store = Mock()
+        gate = self._gate_node(mock_catalog_store)
+        state = SQLGraphState(
+            messages=[],
+            rewrite_question="q unavailable",
+            sql="SELECT 1 FROM test_table",
+            tables=[{"table": "test.test_table"}],
+            confidence_status=CONFIDENCE_STATUS_PARSE_ERROR,
+            confidence_reasons=["unparseable evaluator output"],
+            confidence_diagnostics=["unparseable evaluator output"],
+            sql_execution_result=SQL_SUCCESS,
+        )
+        with (
+            patch("openchatbi.text2sql.generate_sql.config.get", return_value=cfg),
+            patch("openchatbi.text2sql.generate_sql.get_learned_sql_store", return_value=learned_store),
+            patch("openchatbi.text2sql.generate_sql.interrupt") as mock_interrupt,
+        ):
+            out = gate(state)
+        assert out["human_sql_decision"] == "approve"
+        mock_interrupt.assert_not_called()
+        learned_store.add_golden_sql.assert_not_called()
+        examples = mock_catalog_store.get_sql_examples()
+        assert not any(q == "q unavailable" for q, _sql, _t in examples)
 
 
 class TestSearchKnowledgeSqlExamples:

--- a/tests/test_pattern_memory_capture.py
+++ b/tests/test_pattern_memory_capture.py
@@ -16,7 +16,7 @@ from langchain_core.messages import AIMessage
 
 from openchatbi.constants import SQL_SUCCESS
 from openchatbi.graph_state import SQLGraphState
-from openchatbi.text2sql.confidence import ConfidenceResult
+from openchatbi.text2sql.confidence import CONFIDENCE_STATUS_OK, CONFIDENCE_STATUS_PARSE_ERROR, ConfidenceResult
 from openchatbi.text2sql.generate_sql import create_sql_nodes
 
 
@@ -106,6 +106,7 @@ class TestAutoCaptureGate:
         state["sql_execution_result"] = SQL_SUCCESS
         if score is not None:
             state["sql_confidence"] = score
+            state["confidence_status"] = CONFIDENCE_STATUS_OK
         return state
 
     def test_capture_disabled_by_default(self, mock_llm, mock_catalog):
@@ -166,16 +167,37 @@ class TestAutoCaptureGate:
         """No sql_confidence in state (evaluator failed) -> skip capture, never re-evaluate."""
         store = MagicMock()
         gate = self._gate(mock_llm, mock_catalog, store)
+        state = self._scored_state(None)
+        state["confidence_status"] = CONFIDENCE_STATUS_PARSE_ERROR
+        state["confidence_diagnostics"] = ["unparseable evaluator output"]
         with (
             patch("openchatbi.text2sql.generate_sql.get_memory_config", return_value=_mem_cfg()),
             patch("openchatbi.text2sql.generate_sql.config.get", return_value=_main_cfg()),
             patch("openchatbi.text2sql.generate_sql.SimpleSQLEvaluator") as MockEval,
         ):
-            out = gate(self._scored_state(None))
+            out = gate(state)
 
         assert out["human_sql_decision"] == "approve"
         store.add.assert_not_called()
         MockEval.assert_not_called()
+
+    def test_capture_skipped_when_confidence_unavailable_even_with_gate_on(self, mock_llm, mock_catalog):
+        store = MagicMock()
+        gate = self._gate(mock_llm, mock_catalog, store)
+        state = self._scored_state(None)
+        state["confidence_status"] = CONFIDENCE_STATUS_PARSE_ERROR
+        state["confidence_reasons"] = ["unparseable evaluator output"]
+        state["confidence_diagnostics"] = ["unparseable evaluator output"]
+        with (
+            patch("openchatbi.text2sql.generate_sql.get_memory_config", return_value=_mem_cfg()),
+            patch("openchatbi.text2sql.generate_sql.config.get", return_value=_main_cfg(gate_on=True)),
+            patch("openchatbi.text2sql.generate_sql.interrupt") as mock_interrupt,
+        ):
+            out = gate(state)
+
+        assert out["human_sql_decision"] == "approve"
+        store.add.assert_not_called()
+        mock_interrupt.assert_not_called()
 
     def test_human_approve_overrides_threshold(self, mock_llm, mock_catalog):
         """Manual approval captures even below the score threshold (human > S2)."""

--- a/tests/test_text2sql_confidence_gate.py
+++ b/tests/test_text2sql_confidence_gate.py
@@ -10,7 +10,11 @@ from langgraph.types import Command
 from openchatbi.config_loader import Config
 from openchatbi.constants import SQL_SUCCESS
 from openchatbi.graph_state import SQLGraphState, SQLOutputState
-from openchatbi.text2sql.confidence import ConfidenceResult
+from openchatbi.text2sql.confidence import (
+    CONFIDENCE_STATUS_OK,
+    CONFIDENCE_STATUS_PARSE_ERROR,
+    ConfidenceResult,
+)
 
 
 class TestConfidenceGateConfig:
@@ -41,18 +45,24 @@ class TestConfidenceStateFields:
             messages=[HumanMessage(content="q")],
             sql="SELECT 1",
             sql_confidence=0.42,
+            confidence_status=CONFIDENCE_STATUS_OK,
             confidence_reasons=["WHERE clause missing filter"],
+            confidence_diagnostics=[],
             human_sql_decision="approve",
         )
         assert state["sql_confidence"] == 0.42
+        assert state["confidence_status"] == CONFIDENCE_STATUS_OK
         assert state["confidence_reasons"] == ["WHERE clause missing filter"]
+        assert state["confidence_diagnostics"] == []
         assert state["human_sql_decision"] == "approve"
 
     def test_sqloutputstate_exposes_confidence_fields(self):
         # SQLOutputState is the subgraph output schema; fields absent here are
         # filtered out at the subgraph boundary and never reach the parent graph.
         assert "sql_confidence" in SQLOutputState.__annotations__
+        assert "confidence_status" in SQLOutputState.__annotations__
         assert "confidence_reasons" in SQLOutputState.__annotations__
+        assert "confidence_diagnostics" in SQLOutputState.__annotations__
         assert "human_sql_decision" in SQLOutputState.__annotations__
 
 
@@ -109,7 +119,9 @@ class TestScoreSqlNode:
             )
             out = score_sql_node(state)
         assert out["sql_confidence"] == 0.35
+        assert out["confidence_status"] == CONFIDENCE_STATUS_OK
         assert out["confidence_reasons"] == ["WHERE missing"]
+        assert out["confidence_diagnostics"] == []
 
     def test_score_sql_node_skips_on_failed_sql(self, mock_llm, mock_catalog):
         nodes = self._nodes(mock_llm, mock_catalog)
@@ -174,6 +186,39 @@ class TestScoreSqlNode:
             out = score_sql_node(state)
         MockEval.assert_called_once()
         assert out.get("sql_confidence") == 0.9
+        assert out.get("confidence_status") == CONFIDENCE_STATUS_OK
+
+    def test_score_sql_node_unavailable_confidence_has_no_low_score(self, mock_llm, mock_catalog):
+        nodes = self._nodes(mock_llm, mock_catalog)
+        score_sql_node = nodes[4]
+        fake_result = ConfidenceResult(
+            score=None,
+            reasons=["unparseable evaluator output"],
+            checks={},
+            status=CONFIDENCE_STATUS_PARSE_ERROR,
+        )
+        cfg = Config(
+            default_llm=MagicMock(),
+            data_warehouse_config={"uri": "sqlite:///:memory:"},
+            enable_confidence_gate=True,
+        )
+        state = SQLGraphState(
+            messages=[],
+            rewrite_question="q",
+            sql="SELECT 1",
+            schema_info={},
+            data="",
+            sql_execution_result=SQL_SUCCESS,
+        )
+        with (
+            patch("openchatbi.text2sql.generate_sql.config.get", return_value=cfg),
+            patch("openchatbi.text2sql.generate_sql.SimpleSQLEvaluator") as MockEval,
+        ):
+            MockEval.return_value.evaluate.return_value = fake_result
+            out = score_sql_node(state)
+        assert "sql_confidence" not in out
+        assert out["confidence_status"] == CONFIDENCE_STATUS_PARSE_ERROR
+        assert out["confidence_diagnostics"] == ["unparseable evaluator output"]
 
 
 class TestRouteAfterConfidence:
@@ -217,6 +262,7 @@ class TestConfidenceGateEditFallback:
             rewrite_question="q",
             sql="SELECT 1",
             sql_confidence=0.3,
+            confidence_status=CONFIDENCE_STATUS_OK,
             confidence_reasons=["WHERE missing"],
         )
 
@@ -259,6 +305,23 @@ class TestConfidenceGateEditFallback:
         assert out["human_sql_decision"] == "reject"
         assert "sql" not in out
 
+    def test_unavailable_confidence_approves_without_low_confidence_interrupt(self, gate_node):
+        state = SQLGraphState(
+            messages=[],
+            rewrite_question="q",
+            sql="SELECT 1",
+            confidence_status=CONFIDENCE_STATUS_PARSE_ERROR,
+            confidence_reasons=["unparseable evaluator output"],
+            confidence_diagnostics=["unparseable evaluator output"],
+        )
+        with (
+            patch("openchatbi.text2sql.generate_sql.config.get", return_value=self._gated_cfg()),
+            patch("openchatbi.text2sql.generate_sql.interrupt") as mock_interrupt,
+        ):
+            out = gate_node(state)
+        assert out["human_sql_decision"] == "approve"
+        mock_interrupt.assert_not_called()
+
 
 class TestInterruptThroughToolBoundary:
     """Verify the confidence_gate interrupt survives the get_sql_tools
@@ -293,7 +356,11 @@ class TestInterruptThroughToolBoundary:
             return {"sql_execution_result": SQL_SUCCESS, "data": "id\n1\n", "schema_info": {}}
 
         def score_stub(state):
-            return {"sql_confidence": 0.30, "confidence_reasons": ["WHERE missing"]}
+            return {
+                "sql_confidence": 0.30,
+                "confidence_status": CONFIDENCE_STATUS_OK,
+                "confidence_reasons": ["WHERE missing"],
+            }
 
         def viz_stub(state):
             return {"visualization_dsl": {"chart_type": "bar"}}
@@ -385,12 +452,40 @@ class TestConfidenceStreaming:
         events = proc.process(
             namespace=(),
             event_type="updates",
-            event_value={"score_sql": {"sql_confidence": 0.42, "confidence_reasons": ["WHERE missing"]}},
+            event_value={
+                "score_sql": {
+                    "sql_confidence": 0.42,
+                    "confidence_status": CONFIDENCE_STATUS_OK,
+                    "confidence_reasons": ["WHERE missing"],
+                }
+            },
         )
         conf = [e for e in events if isinstance(e, StreamStep) and e.kind == "confidence"]
         assert len(conf) == 1
         assert conf[0].data["sql_confidence"] == 0.42
+        assert conf[0].data["confidence_status"] == CONFIDENCE_STATUS_OK
         assert "0.42" in conf[0].text
+
+    def test_score_sql_emits_unavailable_confidence_step(self):
+        from openchatbi.streaming import AgentStreamProcessor, StreamStep
+
+        proc = AgentStreamProcessor()
+        events = proc.process(
+            namespace=(),
+            event_type="updates",
+            event_value={
+                "score_sql": {
+                    "confidence_status": CONFIDENCE_STATUS_PARSE_ERROR,
+                    "confidence_reasons": ["unparseable evaluator output"],
+                    "confidence_diagnostics": ["unparseable evaluator output"],
+                }
+            },
+        )
+        conf = [e for e in events if isinstance(e, StreamStep) and e.kind == "confidence"]
+        assert len(conf) == 1
+        assert "unavailable" in conf[0].text
+        assert "0.00" not in conf[0].text
+        assert conf[0].data["confidence_status"] == CONFIDENCE_STATUS_PARSE_ERROR
 
     def test_score_sql_node_in_subgraph_nodes(self):
         from openchatbi.streaming import SQL_SUBGRAPH_NODES


### PR DESCRIPTION
## Summary
- Separate Text2SQL confidence evaluator status from numeric SQL confidence scores.
- Treat malformed evaluator output and evaluator invocation errors as confidence unavailable instead of `0.0`.
- Keep user response flow open on evaluator failure, while skipping learned pattern / golden SQL auto-capture without trusted confidence.
- Add regression coverage for evaluator errors, confidence gate routing, streaming metadata, and capture behavior.
- Archive the OpenSpec change and sync `text2sql-confidence-status` into main specs.

## Test Plan
- `pytest tests/test_confidence.py tests/test_text2sql_confidence_gate.py tests/test_pattern_memory_capture.py tests/test_golden_sql_capture.py`
- `ReadLints` on edited Python files: no diagnostics